### PR TITLE
Add GetByteSize to batch interface

### DIFF
--- a/backend_test.go
+++ b/backend_test.go
@@ -346,7 +346,8 @@ func testDBBatchGetByteSize(t *testing.T, backend BackendType) {
 	batchSize, err := batch.GetByteSize()
 	require.NoError(t, err)
 	// size of newly created batch should be 0 or negligible because of the metadata in the batch,
-	// for example peppble's batchHeaderLen is 12 so peppble's batch size will always be equal or greater than 12 even for empty batch
+	// for example peppble's batchHeaderLen is 12 so
+	// peppble's batch size will always be equal or greater than 12 even for empty batch
 	require.LessOrEqual(t, batchSize, 32)
 
 	totalSizeOfKeyAndValue := 0
@@ -360,7 +361,8 @@ func testDBBatchGetByteSize(t *testing.T, backend BackendType) {
 
 	batchSize, err = batch.GetByteSize()
 	require.NoError(t, err)
-	// because of we set a lot of keys and values with considerable size, ratio of batchSize / totalSizeOfKeyAndValue should be roughly 1
+	// because we set a lot of keys and values with considerable size,
+	// ratio of batchSize / totalSizeOfKeyAndValue should be roughly 1
 	require.Equal(t, 1, batchSize/totalSizeOfKeyAndValue)
 
 	err = batch.Write()

--- a/backend_test.go
+++ b/backend_test.go
@@ -347,8 +347,18 @@ func testDBBatch(t *testing.T, backend BackendType) {
 	require.NoError(t, batch.Set([]byte("c"), []byte{3}))
 	assertKeyValues(t, db, map[string][]byte{})
 
+	batchSize, err := batch.GetByteSize()
+	require.NoError(t, err)
+	// batchSize should be grater than 6 which is the total size of keys and values
+	require.GreaterOrEqual(t, batchSize, uint64(6))
+
 	err = batch.Write()
 	require.NoError(t, err)
+
+	_, err = batch.GetByteSize()
+	// calling GetByteSize on a written batch should error
+	require.Error(t, err)
+
 	assertKeyValues(t, db, map[string][]byte{"a": {1}, "b": {2}, "c": {3}})
 
 	// trying to modify or rewrite a written batch should error, but closing it should work
@@ -366,6 +376,12 @@ func testDBBatch(t *testing.T, backend BackendType) {
 	require.NoError(t, batch.Set([]byte("b"), []byte{2}))
 	require.NoError(t, batch.Set([]byte("c"), []byte{3}))
 	require.NoError(t, batch.Delete([]byte("c")))
+
+	batchSize, err = batch.GetByteSize()
+	require.NoError(t, err)
+	// batchSize should be grater than 10 which is the total size of keys and values
+	require.GreaterOrEqual(t, batchSize, uint64(10))
+
 	require.NoError(t, batch.Write())
 	require.NoError(t, batch.Close())
 	assertKeyValues(t, db, map[string][]byte{"a": {1}, "b": {2}})

--- a/backend_test.go
+++ b/backend_test.go
@@ -345,8 +345,9 @@ func testDBBatchGetByteSize(t *testing.T, backend BackendType) {
 	batch := db.NewBatch()
 	batchSize, err := batch.GetByteSize()
 	require.NoError(t, err)
-	// size of newly created batch should be 0 or negligible
-	require.LessOrEqual(t, batchSize, uint32(32))
+	// size of newly created batch should be 0 or negligible because of the metadata in the batch,
+	// for example peppble's batchHeaderLen is 12 so peppble's batch size will always be equal or greater than 12 even for empty batch
+	require.LessOrEqual(t, batchSize, 32)
 
 	totalSizeOfKeyAndValue := 0
 	// set 100 random keys and values
@@ -360,7 +361,7 @@ func testDBBatchGetByteSize(t *testing.T, backend BackendType) {
 	batchSize, err = batch.GetByteSize()
 	require.NoError(t, err)
 	// because of we set a lot of keys and values with considerable size, ratio of batchSize / totalSizeOfKeyAndValue should be roughly 1
-	require.Equal(t, uint32(1), batchSize/uint32(totalSizeOfKeyAndValue))
+	require.Equal(t, 1, batchSize/totalSizeOfKeyAndValue)
 
 	err = batch.Write()
 	require.NoError(t, err)

--- a/backend_test.go
+++ b/backend_test.go
@@ -343,6 +343,10 @@ func testDBBatchGetByteSize(t *testing.T, backend BackendType) {
 
 	// create a new batch
 	batch := db.NewBatch()
+	batchSize, err := batch.GetByteSize()
+	require.NoError(t, err)
+	// size of newly created batch should be 0 or negligible
+	require.LessOrEqual(t, uint32(32), batchSize)
 
 	totalSizeOfKeyAndValue := 0
 	// set 100 random keys and values
@@ -353,7 +357,7 @@ func testDBBatchGetByteSize(t *testing.T, backend BackendType) {
 		require.NoError(t, batch.Set([]byte(randStr(keySize)), []byte(randStr(valueSize))))
 	}
 
-	batchSize, err := batch.GetByteSize()
+	batchSize, err = batch.GetByteSize()
 	require.NoError(t, err)
 	// because of we set a lot of keys and values with considerable size, ratio of batchSize / totalSizeOfKeyAndValue should be roughly 1
 	require.Equal(t, uint32(1), batchSize/uint32(totalSizeOfKeyAndValue))

--- a/backend_test.go
+++ b/backend_test.go
@@ -346,7 +346,7 @@ func testDBBatchGetByteSize(t *testing.T, backend BackendType) {
 	batchSize, err := batch.GetByteSize()
 	require.NoError(t, err)
 	// size of newly created batch should be 0 or negligible
-	require.LessOrEqual(t, uint32(32), batchSize)
+	require.LessOrEqual(t, batchSize, uint32(32))
 
 	totalSizeOfKeyAndValue := 0
 	// set 100 random keys and values
@@ -360,7 +360,7 @@ func testDBBatchGetByteSize(t *testing.T, backend BackendType) {
 	batchSize, err = batch.GetByteSize()
 	require.NoError(t, err)
 	// because of we set a lot of keys and values with considerable size, ratio of batchSize / totalSizeOfKeyAndValue should be roughly 1
-	require.Equal(t, batchSize/uint32(totalSizeOfKeyAndValue), uint32(32))
+	require.Equal(t, uint32(1), batchSize/uint32(totalSizeOfKeyAndValue))
 
 	err = batch.Write()
 	require.NoError(t, err)

--- a/backend_test.go
+++ b/backend_test.go
@@ -360,7 +360,7 @@ func testDBBatchGetByteSize(t *testing.T, backend BackendType) {
 	batchSize, err = batch.GetByteSize()
 	require.NoError(t, err)
 	// because of we set a lot of keys and values with considerable size, ratio of batchSize / totalSizeOfKeyAndValue should be roughly 1
-	require.Equal(t, uint32(1), batchSize/uint32(totalSizeOfKeyAndValue))
+	require.Equal(t, batchSize/uint32(totalSizeOfKeyAndValue), uint32(32))
 
 	err = batch.Write()
 	require.NoError(t, err)

--- a/backend_test.go
+++ b/backend_test.go
@@ -343,14 +343,6 @@ func testDBBatchGetByteSize(t *testing.T, backend BackendType) {
 
 	// create a new batch, and some items - they should not be visible until we write
 	batch := db.NewBatch()
-	batchSize, err := batch.GetByteSize()
-	require.NoError(t, err)
-	// batchSize should be zero for newly created batch, except for rocksdb
-	if backend != "rocksdb" {
-		require.Equal(t, batchSize, uint32(0))
-	} else {
-		require.Equal(t, batchSize, uint32(0xc))
-	}
 
 	totalSizeOfKeyAndValue := 0
 	for i := 0; i < 100; i++ {
@@ -360,7 +352,7 @@ func testDBBatchGetByteSize(t *testing.T, backend BackendType) {
 		require.NoError(t, batch.Set([]byte(randStr(keySize)), []byte(randStr(valueSize))))
 	}
 
-	batchSize, err = batch.GetByteSize()
+	batchSize, err := batch.GetByteSize()
 	require.NoError(t, err)
 	// because of we set a lot of keys and values with considerable size, ratio of batchSize / totalSizeOfKeyAndValue should be roughly 1
 	require.Equal(t, uint32(1), batchSize/uint32(totalSizeOfKeyAndValue))

--- a/backend_test.go
+++ b/backend_test.go
@@ -383,7 +383,6 @@ func testDBBatchOperations(t *testing.T, backend BackendType) {
 
 	// create a new batch, and some items - they should not be visible until we write
 	batch := db.NewBatch()
-
 	require.NoError(t, batch.Set([]byte("a"), []byte{1}))
 	require.NoError(t, batch.Set([]byte("b"), []byte{2}))
 	require.NoError(t, batch.Set([]byte("c"), []byte{3}))
@@ -391,7 +390,6 @@ func testDBBatchOperations(t *testing.T, backend BackendType) {
 
 	err = batch.Write()
 	require.NoError(t, err)
-
 	assertKeyValues(t, db, map[string][]byte{"a": {1}, "b": {2}, "c": {3}})
 
 	// trying to modify or rewrite a written batch should error, but closing it should work
@@ -409,7 +407,6 @@ func testDBBatchOperations(t *testing.T, backend BackendType) {
 	require.NoError(t, batch.Set([]byte("b"), []byte{2}))
 	require.NoError(t, batch.Set([]byte("c"), []byte{3}))
 	require.NoError(t, batch.Delete([]byte("c")))
-
 	require.NoError(t, batch.Write())
 	require.NoError(t, batch.Close())
 	assertKeyValues(t, db, map[string][]byte{"a": {1}, "b": {2}})

--- a/backend_test.go
+++ b/backend_test.go
@@ -341,7 +341,7 @@ func testDBBatchGetByteSize(t *testing.T, backend BackendType) {
 	require.NoError(t, err)
 	defer cleanupDBDir(dir, name)
 
-	// create a new batch, and some items - they should not be visible until we write
+	// create a new batch
 	batch := db.NewBatch()
 
 	totalSizeOfKeyAndValue := 0

--- a/backend_test.go
+++ b/backend_test.go
@@ -354,7 +354,7 @@ func testDBBatch(t *testing.T, backend BackendType) {
 
 	batchSize, err = batch.GetByteSize()
 	require.NoError(t, err)
-	// batchSize should be grater than 6 which is the total size of keys and values
+	// batchSize should be greater than 6 which is the total size of keys and values
 	require.GreaterOrEqual(t, batchSize, uint32(6))
 
 	err = batch.Write()

--- a/backend_test.go
+++ b/backend_test.go
@@ -345,6 +345,7 @@ func testDBBatchGetByteSize(t *testing.T, backend BackendType) {
 	batch := db.NewBatch()
 
 	totalSizeOfKeyAndValue := 0
+	// set 100 random keys and values
 	for i := 0; i < 100; i++ {
 		keySize := rand.Intn(32) + 1
 		valueSize := rand.Intn(32) + 1

--- a/backend_test.go
+++ b/backend_test.go
@@ -342,15 +342,20 @@ func testDBBatch(t *testing.T, backend BackendType) {
 
 	// create a new batch, and some items - they should not be visible until we write
 	batch := db.NewBatch()
+	batchSize, err := batch.GetByteSize()
+	require.NoError(t, err)
+	// batchSize should be zero for newly created batch
+	require.Equal(t, batchSize, uint32(0))
+
 	require.NoError(t, batch.Set([]byte("a"), []byte{1}))
 	require.NoError(t, batch.Set([]byte("b"), []byte{2}))
 	require.NoError(t, batch.Set([]byte("c"), []byte{3}))
 	assertKeyValues(t, db, map[string][]byte{})
 
-	batchSize, err := batch.GetByteSize()
+	batchSize, err = batch.GetByteSize()
 	require.NoError(t, err)
 	// batchSize should be grater than 6 which is the total size of keys and values
-	require.GreaterOrEqual(t, batchSize, uint64(6))
+	require.GreaterOrEqual(t, batchSize, uint32(6))
 
 	err = batch.Write()
 	require.NoError(t, err)
@@ -380,7 +385,7 @@ func testDBBatch(t *testing.T, backend BackendType) {
 	batchSize, err = batch.GetByteSize()
 	require.NoError(t, err)
 	// batchSize should be grater than 10 which is the total size of keys and values
-	require.GreaterOrEqual(t, batchSize, uint64(10))
+	require.GreaterOrEqual(t, batchSize, uint32(10))
 
 	require.NoError(t, batch.Write())
 	require.NoError(t, batch.Close())

--- a/cleveldb_batch.go
+++ b/cleveldb_batch.go
@@ -9,7 +9,7 @@ import "github.com/jmhodges/levigo"
 type cLevelDBBatch struct {
 	db    *CLevelDB
 	batch *levigo.WriteBatch
-	size  uint64
+	size  uint32
 }
 
 func newCLevelDBBatch(db *CLevelDB) *cLevelDBBatch {
@@ -31,7 +31,7 @@ func (b *cLevelDBBatch) Set(key, value []byte) error {
 	if b.batch == nil {
 		return errBatchClosed
 	}
-	b.size += uint64(len(key) + len(value))
+	b.size += uint32(len(key) + len(value))
 	b.batch.Put(key, value)
 	return nil
 }
@@ -44,7 +44,7 @@ func (b *cLevelDBBatch) Delete(key []byte) error {
 	if b.batch == nil {
 		return errBatchClosed
 	}
-	b.size += uint64(len(key))
+	b.size += uint32(len(key))
 	b.batch.Delete(key)
 	return nil
 }
@@ -87,7 +87,7 @@ func (b *cLevelDBBatch) Close() error {
 }
 
 // GetByteSize implements Batch
-func (b *cLevelDBBatch) GetByteSize() (uint64, error) {
+func (b *cLevelDBBatch) GetByteSize() (uint32, error) {
 	if b.batch == nil {
 		return 0, errBatchClosed
 	}

--- a/cleveldb_batch.go
+++ b/cleveldb_batch.go
@@ -80,6 +80,7 @@ func (b *cLevelDBBatch) Close() error {
 	if b.batch != nil {
 		b.batch.Close()
 		b.batch = nil
+		b.size = 0
 	}
 	return nil
 }

--- a/cleveldb_batch.go
+++ b/cleveldb_batch.go
@@ -9,6 +9,7 @@ import "github.com/jmhodges/levigo"
 type cLevelDBBatch struct {
 	db    *CLevelDB
 	batch *levigo.WriteBatch
+	size  uint64
 }
 
 func newCLevelDBBatch(db *CLevelDB) *cLevelDBBatch {
@@ -29,6 +30,7 @@ func (b *cLevelDBBatch) Set(key, value []byte) error {
 	if b.batch == nil {
 		return errBatchClosed
 	}
+	b.size += uint64(len(key) + len(value))
 	b.batch.Put(key, value)
 	return nil
 }
@@ -41,6 +43,7 @@ func (b *cLevelDBBatch) Delete(key []byte) error {
 	if b.batch == nil {
 		return errBatchClosed
 	}
+	b.size += uint64(len(key))
 	b.batch.Delete(key)
 	return nil
 }
@@ -79,4 +82,12 @@ func (b *cLevelDBBatch) Close() error {
 		b.batch = nil
 	}
 	return nil
+}
+
+// GetByteSize implements Batch
+func (b *cLevelDBBatch) GetByteSize() (uint64, error) {
+	if b.batch == nil {
+		return 0, errBatchClosed
+	}
+	return b.size, nil
 }

--- a/cleveldb_batch.go
+++ b/cleveldb_batch.go
@@ -16,6 +16,7 @@ func newCLevelDBBatch(db *CLevelDB) *cLevelDBBatch {
 	return &cLevelDBBatch{
 		db:    db,
 		batch: levigo.NewWriteBatch(),
+		size:  0,
 	}
 }
 

--- a/cleveldb_batch.go
+++ b/cleveldb_batch.go
@@ -9,7 +9,7 @@ import "github.com/jmhodges/levigo"
 type cLevelDBBatch struct {
 	db    *CLevelDB
 	batch *levigo.WriteBatch
-	size  uint32
+	size  int
 }
 
 func newCLevelDBBatch(db *CLevelDB) *cLevelDBBatch {
@@ -31,7 +31,7 @@ func (b *cLevelDBBatch) Set(key, value []byte) error {
 	if b.batch == nil {
 		return errBatchClosed
 	}
-	b.size += uint32(len(key) + len(value))
+	b.size += len(key) + len(value)
 	b.batch.Put(key, value)
 	return nil
 }
@@ -44,7 +44,7 @@ func (b *cLevelDBBatch) Delete(key []byte) error {
 	if b.batch == nil {
 		return errBatchClosed
 	}
-	b.size += uint32(len(key))
+	b.size += len(key)
 	b.batch.Delete(key)
 	return nil
 }
@@ -87,7 +87,7 @@ func (b *cLevelDBBatch) Close() error {
 }
 
 // GetByteSize implements Batch
-func (b *cLevelDBBatch) GetByteSize() (uint32, error) {
+func (b *cLevelDBBatch) GetByteSize() (int, error) {
 	if b.batch == nil {
 		return 0, errBatchClosed
 	}

--- a/goleveldb_batch.go
+++ b/goleveldb_batch.go
@@ -78,9 +78,9 @@ func (b *goLevelDBBatch) Close() error {
 }
 
 // GetByteSize implements Batch
-func (b *goLevelDBBatch) GetByteSize() (uint32, error) {
+func (b *goLevelDBBatch) GetByteSize() (int, error) {
 	if b.batch == nil {
 		return 0, errBatchClosed
 	}
-	return uint32(len(b.batch.Dump())), nil
+	return len(b.batch.Dump()), nil
 }

--- a/goleveldb_batch.go
+++ b/goleveldb_batch.go
@@ -76,3 +76,11 @@ func (b *goLevelDBBatch) Close() error {
 	}
 	return nil
 }
+
+// GetByteSize implements Batch
+func (b *goLevelDBBatch) GetByteSize() (uint64, error) {
+	if b.batch == nil {
+		return 0, errBatchClosed
+	}
+	return uint64(len(b.batch.Dump())), nil
+}

--- a/goleveldb_batch.go
+++ b/goleveldb_batch.go
@@ -78,9 +78,9 @@ func (b *goLevelDBBatch) Close() error {
 }
 
 // GetByteSize implements Batch
-func (b *goLevelDBBatch) GetByteSize() (uint64, error) {
+func (b *goLevelDBBatch) GetByteSize() (uint32, error) {
 	if b.batch == nil {
 		return 0, errBatchClosed
 	}
-	return uint64(len(b.batch.Dump())), nil
+	return uint32(len(b.batch.Dump())), nil
 }

--- a/memdb_batch.go
+++ b/memdb_batch.go
@@ -93,6 +93,7 @@ func (b *memDBBatch) WriteSync() error {
 // Close implements Batch.
 func (b *memDBBatch) Close() error {
 	b.ops = nil
+	b.size = 0
 	return nil
 }
 

--- a/memdb_batch.go
+++ b/memdb_batch.go
@@ -20,7 +20,7 @@ type operation struct {
 type memDBBatch struct {
 	db   *MemDB
 	ops  []operation
-	size uint32
+	size int
 }
 
 var _ Batch = (*memDBBatch)(nil)
@@ -45,7 +45,7 @@ func (b *memDBBatch) Set(key, value []byte) error {
 	if b.ops == nil {
 		return errBatchClosed
 	}
-	b.size += uint32(len(key) + len(value))
+	b.size += len(key) + len(value)
 	b.ops = append(b.ops, operation{opTypeSet, key, value})
 	return nil
 }
@@ -58,7 +58,7 @@ func (b *memDBBatch) Delete(key []byte) error {
 	if b.ops == nil {
 		return errBatchClosed
 	}
-	b.size += uint32(len(key))
+	b.size += len(key)
 	b.ops = append(b.ops, operation{opTypeDelete, key, nil})
 	return nil
 }
@@ -99,7 +99,7 @@ func (b *memDBBatch) Close() error {
 }
 
 // GetByteSize implements Batch
-func (b *memDBBatch) GetByteSize() (uint32, error) {
+func (b *memDBBatch) GetByteSize() (int, error) {
 	if b.ops == nil {
 		return 0, errBatchClosed
 	}

--- a/memdb_batch.go
+++ b/memdb_batch.go
@@ -28,8 +28,9 @@ var _ Batch = (*memDBBatch)(nil)
 // newMemDBBatch creates a new memDBBatch
 func newMemDBBatch(db *MemDB) *memDBBatch {
 	return &memDBBatch{
-		db:  db,
-		ops: []operation{},
+		db:   db,
+		ops:  []operation{},
+		size: 0,
 	}
 }
 

--- a/memdb_batch.go
+++ b/memdb_batch.go
@@ -20,7 +20,7 @@ type operation struct {
 type memDBBatch struct {
 	db   *MemDB
 	ops  []operation
-	size uint64
+	size uint32
 }
 
 var _ Batch = (*memDBBatch)(nil)
@@ -45,7 +45,7 @@ func (b *memDBBatch) Set(key, value []byte) error {
 	if b.ops == nil {
 		return errBatchClosed
 	}
-	b.size += uint64(len(key) + len(value))
+	b.size += uint32(len(key) + len(value))
 	b.ops = append(b.ops, operation{opTypeSet, key, value})
 	return nil
 }
@@ -58,7 +58,7 @@ func (b *memDBBatch) Delete(key []byte) error {
 	if b.ops == nil {
 		return errBatchClosed
 	}
-	b.size += uint64(len(key))
+	b.size += uint32(len(key))
 	b.ops = append(b.ops, operation{opTypeDelete, key, nil})
 	return nil
 }
@@ -99,7 +99,7 @@ func (b *memDBBatch) Close() error {
 }
 
 // GetByteSize implements Batch
-func (b *memDBBatch) GetByteSize() (uint64, error) {
+func (b *memDBBatch) GetByteSize() (uint32, error) {
 	if b.ops == nil {
 		return 0, errBatchClosed
 	}

--- a/pebble.go
+++ b/pebble.go
@@ -364,11 +364,11 @@ func (b *pebbleDBBatch) Close() error {
 }
 
 // GetByteSize implements Batch
-func (b *pebbleDBBatch) GetByteSize() (uint32, error) {
+func (b *pebbleDBBatch) GetByteSize() (int, error) {
 	if b.batch == nil {
 		return 0, errBatchClosed
 	}
-	return uint32(b.batch.Len()), nil
+	return b.batch.Len(), nil
 }
 
 type pebbleDBIterator struct {

--- a/pebble.go
+++ b/pebble.go
@@ -364,11 +364,11 @@ func (b *pebbleDBBatch) Close() error {
 }
 
 // GetByteSize implements Batch
-func (b *pebbleDBBatch) GetByteSize() (uint64, error) {
+func (b *pebbleDBBatch) GetByteSize() (uint32, error) {
 	if b.batch == nil {
 		return 0, errBatchClosed
 	}
-	return uint64(b.batch.Len()), nil
+	return uint32(b.batch.Len()), nil
 }
 
 type pebbleDBIterator struct {

--- a/pebble.go
+++ b/pebble.go
@@ -363,6 +363,14 @@ func (b *pebbleDBBatch) Close() error {
 	return nil
 }
 
+// GetByteSize implements Batch
+func (b *pebbleDBBatch) GetByteSize() (uint64, error) {
+	if b.batch == nil {
+		return 0, errBatchClosed
+	}
+	return uint64(b.batch.Len()), nil
+}
+
 type pebbleDBIterator struct {
 	source     *pebble.Iterator
 	start, end []byte

--- a/prefixdb_batch.go
+++ b/prefixdb_batch.go
@@ -51,7 +51,7 @@ func (pb prefixDBBatch) Close() error {
 }
 
 // GetByteSize implements Batch
-func (pb prefixDBBatch) GetByteSize() (uint64, error) {
+func (pb prefixDBBatch) GetByteSize() (uint32, error) {
 	if pb.source == nil {
 		return 0, errBatchClosed
 	}

--- a/prefixdb_batch.go
+++ b/prefixdb_batch.go
@@ -51,7 +51,7 @@ func (pb prefixDBBatch) Close() error {
 }
 
 // GetByteSize implements Batch
-func (pb prefixDBBatch) GetByteSize() (uint32, error) {
+func (pb prefixDBBatch) GetByteSize() (int, error) {
 	if pb.source == nil {
 		return 0, errBatchClosed
 	}

--- a/prefixdb_batch.go
+++ b/prefixdb_batch.go
@@ -49,3 +49,11 @@ func (pb prefixDBBatch) WriteSync() error {
 func (pb prefixDBBatch) Close() error {
 	return pb.source.Close()
 }
+
+// GetByteSize implements Batch
+func (pb prefixDBBatch) GetByteSize() (uint64, error) {
+	if pb.source == nil {
+		return 0, errBatchClosed
+	}
+	return pb.source.GetByteSize()
+}

--- a/rocksdb_batch.go
+++ b/rocksdb_batch.go
@@ -83,9 +83,9 @@ func (b *rocksDBBatch) Close() error {
 }
 
 // GetByteSize implements Batch
-func (b *rocksDBBatch) GetByteSize() (uint32, error) {
+func (b *rocksDBBatch) GetByteSize() (int, error) {
 	if b.batch == nil {
 		return 0, errBatchClosed
 	}
-	return uint32(len(b.batch.Data())), nil
+	return len(b.batch.Data()), nil
 }

--- a/rocksdb_batch.go
+++ b/rocksdb_batch.go
@@ -81,3 +81,11 @@ func (b *rocksDBBatch) Close() error {
 	}
 	return nil
 }
+
+// GetByteSize implements Batch
+func (b *rocksDBBatch) GetByteSize() (uint64, error) {
+	if b.batch == nil {
+		return 0, errBatchClosed
+	}
+	return uint64(len(b.batch.Data())), nil
+}

--- a/rocksdb_batch.go
+++ b/rocksdb_batch.go
@@ -83,9 +83,9 @@ func (b *rocksDBBatch) Close() error {
 }
 
 // GetByteSize implements Batch
-func (b *rocksDBBatch) GetByteSize() (uint64, error) {
+func (b *rocksDBBatch) GetByteSize() (uint32, error) {
 	if b.batch == nil {
 		return 0, errBatchClosed
 	}
-	return uint64(len(b.batch.Data())), nil
+	return uint32(len(b.batch.Data())), nil
 }

--- a/types.go
+++ b/types.go
@@ -98,7 +98,7 @@ type Batch interface {
 	// GetByteSize that returns the current size of the batch in bytes. Depending on the implementation,
 	// this may return the size of the underlying LSM batch, including the size of additional metadata
 	// on top of the expected key and value total byte count.
-	GetByteSize() (uint32, error)
+	GetByteSize() (int, error)
 }
 
 // Iterator represents an iterator over a domain of keys. Callers must call Close when done.

--- a/types.go
+++ b/types.go
@@ -96,7 +96,7 @@ type Batch interface {
 	Close() error
 
 	// GetByteSize that returns the current size of the batch in bytes.
-	GetByteSize() (uint64, error)
+	GetByteSize() (uint32, error)
 }
 
 // Iterator represents an iterator over a domain of keys. Callers must call Close when done.

--- a/types.go
+++ b/types.go
@@ -94,6 +94,9 @@ type Batch interface {
 
 	// Close closes the batch. It is idempotent, but calls to other methods afterwards will error.
 	Close() error
+
+	// GetByteSize that returns the current size of the batch in bytes.
+	GetByteSize() (uint64, error)
 }
 
 // Iterator represents an iterator over a domain of keys. Callers must call Close when done.

--- a/types.go
+++ b/types.go
@@ -95,7 +95,9 @@ type Batch interface {
 	// Close closes the batch. It is idempotent, but calls to other methods afterwards will error.
 	Close() error
 
-	// GetByteSize that returns the current size of the batch in bytes.
+	// GetByteSize that returns the current size of the batch in bytes. Depending on the implementation,
+	// this may return the size of the underlying LSM batch, including the size of additional metadata
+	// on top of the expected key and value total byte count.
 	GetByteSize() (uint32, error)
 }
 


### PR DESCRIPTION
Closes #58 

## Purpose
I add GetByteSize to batch interface and its implementation

## Implementation

For `cleveldb`, `memdb`. I add a field `size` into its `Batch`. Everytime `Set` and `Delete` is called, `size` will increase an amount equal to len(key) + len(value), len(value) is 0 if it's `Delete`, in other words `size` field equals to the `total size of all the keys and values`. Note that `total size of all the keys and values` doesn't necessary equal to the actual data size of the `Batch` since that data could also contain metadata and separation, so Idk if this is okay or not. I do this because there's no way to access the underneath data or len(data) of the batchs.


For `goleveldb`, `pebbledb`, `rocksdb`, `perfixdb`, I don't need to add new feild `size` since there's already a way to access the underneath data or len(data) of the batchs.


