### PR TITLE
Add `NewBatchWithSize` to DB interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,4 @@
 
 - added bloom filter:  https://github.com/cosmos/cosmos-db/pull/42/files
 - Removed Badger & Boltdb
+- Add `NewBatchWithSize` to `DB` interface: https://github.com/cosmos/cosmos-db/pull/64

--- a/goleveldb.go
+++ b/goleveldb.go
@@ -187,6 +187,11 @@ func (db *GoLevelDB) NewBatch() Batch {
 	return newGoLevelDBBatch(db)
 }
 
+// NewBatchWithSize implements DB.
+func (db *GoLevelDB) NewBatchWithSize(size int) Batch {
+	return newGoLevelDBBatchWithSize(db, size)
+}
+
 // Iterator implements DB.
 func (db *GoLevelDB) Iterator(start, end []byte) (Iterator, error) {
 	if (start != nil && len(start) == 0) || (end != nil && len(end) == 0) {

--- a/goleveldb_batch.go
+++ b/goleveldb_batch.go
@@ -19,6 +19,13 @@ func newGoLevelDBBatch(db *GoLevelDB) *goLevelDBBatch {
 	}
 }
 
+func newGoLevelDBBatchWithSize(db *GoLevelDB, size int) *goLevelDBBatch {
+	return &goLevelDBBatch{
+		db:    db,
+		batch: leveldb.MakeBatch(size),
+	}
+}
+
 // Set implements Batch.
 func (b *goLevelDBBatch) Set(key, value []byte) error {
 	if len(key) == 0 {

--- a/memdb.go
+++ b/memdb.go
@@ -173,6 +173,11 @@ func (db *MemDB) NewBatch() Batch {
 	return newMemDBBatch(db)
 }
 
+// NewBatchWithSize implements DB.
+func (db *MemDB) NewBatchWithSize(size int) Batch {
+	return newMemDBBatch(db)
+}
+
 // Iterator implements DB.
 // Takes out a read-lock on the database until the iterator is closed.
 func (db *MemDB) Iterator(start, end []byte) (Iterator, error) {

--- a/memdb.go
+++ b/memdb.go
@@ -174,6 +174,7 @@ func (db *MemDB) NewBatch() Batch {
 }
 
 // NewBatchWithSize implements DB.
+// It does the same thing as NewBatch because we can't pre-allocate memDBBatch
 func (db *MemDB) NewBatchWithSize(size int) Batch {
 	return newMemDBBatch(db)
 }

--- a/pebble.go
+++ b/pebble.go
@@ -241,6 +241,7 @@ func (db *PebbleDB) NewBatch() Batch {
 }
 
 // NewBatchWithSize implements DB.
+// It does the same thing as NewBatch because we can't pre-allocate pebbleDBBatch
 func (db *PebbleDB) NewBatchWithSize(size int) Batch {
 	return newPebbleDBBatch(db)
 }

--- a/pebble.go
+++ b/pebble.go
@@ -240,6 +240,11 @@ func (db *PebbleDB) NewBatch() Batch {
 	return newPebbleDBBatch(db)
 }
 
+// NewBatchWithSize implements DB.
+func (db *PebbleDB) NewBatchWithSize(size int) Batch {
+	return newPebbleDBBatch(db)
+}
+
 // Iterator implements DB.
 func (db *PebbleDB) Iterator(start, end []byte) (Iterator, error) {
 	// fmt.Println("PebbleDB.Iterator")

--- a/prefixdb.go
+++ b/prefixdb.go
@@ -143,6 +143,11 @@ func (pdb *PrefixDB) NewBatch() Batch {
 	return newPrefixBatch(pdb.prefix, pdb.db.NewBatch())
 }
 
+// NewBatchWithSize implements DB.
+func (pdb *PrefixDB) NewBatchWithSize(size int) Batch {
+	return newPrefixBatch(pdb.prefix, pdb.db.NewBatchWithSize(size))
+}
+
 // Close implements DB.
 func (pdb *PrefixDB) Close() error {
 	pdb.mtx.Lock()

--- a/rocksdb.go
+++ b/rocksdb.go
@@ -183,6 +183,7 @@ func (db *RocksDB) NewBatch() Batch {
 }
 
 // NewBatchWithSize implements DB.
+// It does the same thing as NewBatch because we can't pre-allocate rocksDBBatch
 func (db *RocksDB) NewBatchWithSize(size int) Batch {
 	return newRocksDBBatch(db)
 }

--- a/rocksdb.go
+++ b/rocksdb.go
@@ -182,6 +182,11 @@ func (db *RocksDB) NewBatch() Batch {
 	return newRocksDBBatch(db)
 }
 
+// NewBatchWithSize implements DB.
+func (db *RocksDB) NewBatchWithSize(size int) Batch {
+	return newRocksDBBatch(db)
+}
+
 // Iterator implements DB.
 func (db *RocksDB) Iterator(start, end []byte) (Iterator, error) {
 	if (start != nil && len(start) == 0) || (end != nil && len(end) == 0) {

--- a/types.go
+++ b/types.go
@@ -63,6 +63,9 @@ type DB interface {
 	// NewBatch creates a batch for atomic updates. The caller must call Batch.Close.
 	NewBatch() Batch
 
+	// NewBatchWithSize create a new batch for atomic updates, but with pre-allocated size
+	NewBatchWithSize(int) Batch
+
 	// Print is used for debugging.
 	Print() error
 

--- a/types.go
+++ b/types.go
@@ -63,7 +63,8 @@ type DB interface {
 	// NewBatch creates a batch for atomic updates. The caller must call Batch.Close.
 	NewBatch() Batch
 
-	// NewBatchWithSize create a new batch for atomic updates, but with pre-allocated size
+	// NewBatchWithSize create a new batch for atomic updates, but with pre-allocated size.
+	// This will does the same thing as NewBatch if the batch implementation doesn't support pre-allocation.
 	NewBatchWithSize(int) Batch
 
 	// Print is used for debugging.


### PR DESCRIPTION
Closes: #63 

- This PR add new method for creating pre-allocated batch to DB interface.
- Currently, there's only goleveldb that supports pre-allocating batch. @p0mvn said we should add the method anyway and have all the other db whose batch doesn't support pre-allocation create new empty batch without allocation for `NewBatchWithSize`.
