### PR TITLE
minor golangci-lint changes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,14 @@
+run:
+  build-tags: 
+    - rocksdb
+  concurrency: 4
+  sort-results: true
+  allow-parallel-runners: true
+  tests: true
+
 linters:
   disable-all: true
   enable:
-    - deadcode
     - depguard
     - dogsled
     - dupl
@@ -25,9 +32,5 @@ linters:
     - revive
     - unconvert
     - unused
-    - varcheck
     - nolintlint
 
-run:
-  build-tags:
-    - rocksdb

--- a/backend_test.go
+++ b/backend_test.go
@@ -353,8 +353,8 @@ func testDBBatchGetByteSize(t *testing.T, backend BackendType) {
 	totalSizeOfKeyAndValue := 0
 	// set 100 random keys and values
 	for i := 0; i < 100; i++ {
-		keySize := rand.Intn(32) + 1
-		valueSize := rand.Intn(32) + 1
+		keySize := rand.Intn(32) + 1   //nolint:gosec
+		valueSize := rand.Intn(32) + 1 //nolint:gosec
 		totalSizeOfKeyAndValue += keySize + valueSize
 		require.NoError(t, batch.Set([]byte(randStr(keySize)), []byte(randStr(valueSize))))
 	}


### PR DESCRIPTION
This PR:

* lints tests
* sorts results
* fixes a minor linter finding
* allows parallel runners
