### PR TITLE
add api `NewRocksDBWithRaw` to support different open mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,4 @@
 - added bloom filter:  https://github.com/cosmos/cosmos-db/pull/42/files
 - Removed Badger & Boltdb
 - Add `NewBatchWithSize` to `DB` interface: https://github.com/cosmos/cosmos-db/pull/64
+- Add `NewRocksDBWithRaw` to support different rocksdb open mode (read-only, secondary-standby).

--- a/rocksdb.go
+++ b/rocksdb.go
@@ -78,7 +78,7 @@ func NewRocksDBWithOptions(name string, dir string, opts *grocksdb.Options) (*Ro
 // or customize the default read/write options.
 func NewRocksDBWithRaw(
 	db *grocksdb.DB, ro *grocksdb.ReadOptions,
-	wo *grocksdb.WriteOptions, woSync *grocksdb.WriteOptions
+	wo *grocksdb.WriteOptions, woSync *grocksdb.WriteOptions,
 ) *RocksDB {
 	return &RocksDB{
 		db:     db,

--- a/rocksdb.go
+++ b/rocksdb.go
@@ -71,13 +71,21 @@ func NewRocksDBWithOptions(name string, dir string, opts *grocksdb.Options) (*Ro
 	wo := grocksdb.NewDefaultWriteOptions()
 	woSync := grocksdb.NewDefaultWriteOptions()
 	woSync.SetSync(true)
-	database := &RocksDB{
+	return NewRocksDBWithRaw(db, ro, wo, woSync), nil
+}
+
+// NewRocksDBWithRaw is useful if user want to create the db in read-only or seconday-standby mode,
+// or customize the default read/write options.
+func NewRocksDBWithRaw(
+	db *grocksdb.DB, ro *grocksdb.ReadOptions,
+	wo *grocksdb.WriteOptions, woSync *grocksdb.WriteOptions
+) *RocksDB {
+	return &RocksDB{
 		db:     db,
 		ro:     ro,
 		wo:     wo,
 		woSync: woSync,
 	}
-	return database, nil
 }
 
 // Get implements DB.


### PR DESCRIPTION
it's useful for opening db in read-only mode in --grpc-only node, and other offline commands which want to read the same db without stopping the node.

there could be some usage for secondary-standby mode as well, which is like read-only mode but can catch up with latest writes from time to time.

port the pr from tm-db: https://github.com/tendermint/tm-db/pull/310

ref: https://github.com/facebook/rocksdb/wiki/Read-only-and-Secondary-instances