### PR TITLE
feat: allow full control on rocksdb db opening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## UNRELEASED
+
+* Allow full control in rocksdb opening
+
 ## [v1.0.2] - 2024-02-26
 
 * Downgrade Go version in go.mod to 1.19

--- a/prefixdb_test.go
+++ b/prefixdb_test.go
@@ -2,9 +2,9 @@ package db
 
 import (
 	"bytes"
+	"crypto/rand"
 	"encoding/binary"
 	"fmt"
-	"math/rand"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -32,7 +32,7 @@ func taskKey(i, k int) []byte {
 
 func randomValue() []byte {
 	b := make([]byte, 16)
-	rand.Read(b) //nolint:staticcheck,gosec
+	rand.Read(b)
 	return b
 }
 

--- a/prefixdb_test.go
+++ b/prefixdb_test.go
@@ -32,7 +32,10 @@ func taskKey(i, k int) []byte {
 
 func randomValue() []byte {
 	b := make([]byte, 16)
-	rand.Read(b)
+	_, err := rand.Read(b)
+	if err != nil {
+	    panic(fmt.Sprintf("random value generation failed: %v", err))
+	}
 	return b
 }
 

--- a/rocksdb.go
+++ b/rocksdb.go
@@ -71,7 +71,17 @@ func NewRocksDBWithOptions(name string, dir string, opts *grocksdb.Options) (*Ro
 	wo := grocksdb.NewDefaultWriteOptions()
 	woSync := grocksdb.NewDefaultWriteOptions()
 	woSync.SetSync(true)
-	return NewRocksDBWithRaw(db, ro, wo, woSync), nil
+	return NewRocksDBWithRawDB(db, ro, wo, woSync), nil
+}
+
+// NewRocksDBWithRawDB lets caller has full control on how the db instance is constructed
+func NewRocksDBWithRawDB(
+	db *grocksdb.DB,
+	ro *grocksdb.ReadOptions,
+	wo *grocksdb.WriteOptions,
+	woSync *grocksdb.WriteOptions,
+) *RocksDB {
+	return NewRocksDBWithRaw(db, ro, wo, woSync)
 }
 
 // NewRocksDBWithRaw is useful if user want to create the db in read-only or seconday-standby mode,


### PR DESCRIPTION
this API was previously supported in cometbft-db and used by us to support multiple processes reading from the same db concurrently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a feature for enhanced control over RocksDB initialization.
- **Refactor**
	- Updated random number generation to use secure methods in tests.
	- Improved RocksDB construction process for consistency and flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->