### PR TITLE
chore: make a type alias in DB interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## UNRELEASED
 
 * Allow full control in rocksdb opening
+* Make `Iteractor` and `Batch` interfaces more flexible by a type alias
 
 ## [v1.0.2] - 2024-02-26
 

--- a/types.go
+++ b/types.go
@@ -81,7 +81,7 @@ type DB interface {
 //
 // As with DB, given keys and values should be considered read-only, and must not be modified after
 // passing them to the batch.
-type Batch interface {
+type Batch = interface {
 	// Set sets a key/value pair.
 	// CONTRACT: key, value readonly []byte
 	Set(key, value []byte) error
@@ -130,7 +130,7 @@ type Batch interface {
 //	if err := itr.Error(); err != nil {
 //	  ...
 //	}
-type Iterator interface {
+type Iterator = interface {
 	// Domain returns the start (inclusive) and end (exclusive) limits of the iterator.
 	// CONTRACT: start, end readonly []byte
 	Domain() (start []byte, end []byte)


### PR DESCRIPTION
## Context

ref: https://github.com/cosmos/cosmos-sdk/issues/21225

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced enhanced configurability for opening RocksDB, improving database management and performance.
  
- **Refactor**
	- Updated the declaration of `Batch` and `Iterator` interfaces to use type aliasing for improved readability and maintainability. 

- **Impact**
	- No changes to the methods and contracts of the interfaces; however, users may notice a more streamlined representation in the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->