### PR TITLE
refactor: add named interface for type alias

### DIFF
--- a/types.go
+++ b/types.go
@@ -81,7 +81,7 @@ type DB interface {
 //
 // As with DB, given keys and values should be considered read-only, and must not be modified after
 // passing them to the batch.
-type IBatch interface {
+type BatchI interface {
 	// Set sets a key/value pair.
 	// CONTRACT: key, value readonly []byte
 	Set(key, value []byte) error
@@ -132,7 +132,7 @@ type Batch = IBatch
 //	if err := itr.Error(); err != nil {
 //	  ...
 //	}
-type IIterator interface {
+type IteratorI interface {
 	// Domain returns the start (inclusive) and end (exclusive) limits of the iterator.
 	// CONTRACT: start, end readonly []byte
 	Domain() (start []byte, end []byte)

--- a/types.go
+++ b/types.go
@@ -81,7 +81,7 @@ type DB interface {
 //
 // As with DB, given keys and values should be considered read-only, and must not be modified after
 // passing them to the batch.
-type Batch = interface {
+type IBatch interface {
 	// Set sets a key/value pair.
 	// CONTRACT: key, value readonly []byte
 	Set(key, value []byte) error
@@ -107,6 +107,8 @@ type Batch = interface {
 	GetByteSize() (int, error)
 }
 
+type Batch = IBatch
+
 // Iterator represents an iterator over a domain of keys. Callers must call Close when done.
 // No writes can happen to a domain while there exists an iterator over it, some backends may take
 // out database locks to ensure this will not happen.
@@ -130,7 +132,7 @@ type Batch = interface {
 //	if err := itr.Error(); err != nil {
 //	  ...
 //	}
-type Iterator = interface {
+type IIterator interface {
 	// Domain returns the start (inclusive) and end (exclusive) limits of the iterator.
 	// CONTRACT: start, end readonly []byte
 	Domain() (start []byte, end []byte)
@@ -157,3 +159,5 @@ type Iterator = interface {
 	// Close closes the iterator, relasing any allocated resources.
 	Close() error
 }
+
+type Iterator = IIterator

--- a/types.go
+++ b/types.go
@@ -107,7 +107,7 @@ type BatchI interface {
 	GetByteSize() (int, error)
 }
 
-type Batch = IBatch
+type Batch = BatchI
 
 // Iterator represents an iterator over a domain of keys. Callers must call Close when done.
 // No writes can happen to a domain while there exists an iterator over it, some backends may take
@@ -160,4 +160,4 @@ type IteratorI interface {
 	Close() error
 }
 
-type Iterator = IIterator
+type Iterator = IteratorI


### PR DESCRIPTION
to avoid cannot handle non-empty unnamed interfaces error when `mockgen -package mock -destination store/mock/cosmos_cosmos_db_DB.go github.com/cosmos/cosmos-db DB` 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated internal interface naming for improved clarity while maintaining compatibility with existing type names. No changes to functionality or behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->