### PR TITLE
chore: revert "refactor: add named interface for type alias (#127)" and retract tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## [v1.1.2] - 2025-05-28
+## [v1.1.3] - 2025-06-03
+
+* Revert commit `38785e92904d435a97e0d1b171089278bddf6760` - "Make `Iterator` and `Batch` interfaces more flexible by a type alias"
+
+## [v1.1.2] - 2025-05-28 (RETRACTED)
 
 * Make `Iterator` and `Batch` interfaces more flexible by a type alias
 * Update deps to the latest versions

--- a/go.mod
+++ b/go.mod
@@ -47,3 +47,5 @@ require (
 // grocksdb stays at v1.8.x in cosmos-db as it should support RocksDB v8.
 // the cosmos sdk v2 uses directly store/v2 which uses RocksDB v9 from 0.52+
 replace github.com/linxGnu/grocksdb => github.com/linxGnu/grocksdb v1.8.12
+
+retract v1.1.2

--- a/types.go
+++ b/types.go
@@ -133,7 +133,7 @@ type Batch = interface {
 type Iterator = interface {
 	// Domain returns the start (inclusive) and end (exclusive) limits of the iterator.
 	// CONTRACT: start, end readonly []byte
-	Domain() (start []byte, end []byte)
+	Domain() (start, end []byte)
 
 	// Valid returns whether the current iterator is valid. Once invalid, the Iterator remains
 	// invalid forever.

--- a/types.go
+++ b/types.go
@@ -76,12 +76,12 @@ type DB interface {
 	Stats() map[string]string
 }
 
-// BatchI represents a group of writes. They may or may not be written atomically depending on the
+// Batch represents a group of writes. They may or may not be written atomically depending on the
 // backend. Callers must call Close on the batch when done.
 //
 // As with DB, given keys and values should be considered read-only, and must not be modified after
 // passing them to the batch.
-type BatchI interface {
+type Batch = interface {
 	// Set sets a key/value pair.
 	// CONTRACT: key, value readonly []byte
 	Set(key, value []byte) error
@@ -107,9 +107,7 @@ type BatchI interface {
 	GetByteSize() (int, error)
 }
 
-type Batch = BatchI
-
-// IteratorI represents an iterator over a domain of keys. Callers must call Close when done.
+// Iterator represents an iterator over a domain of keys. Callers must call Close when done.
 // No writes can happen to a domain while there exists an iterator over it, some backends may take
 // out database locks to ensure this will not happen.
 //
@@ -132,10 +130,10 @@ type Batch = BatchI
 //	if err := itr.Error(); err != nil {
 //	  ...
 //	}
-type IteratorI interface {
+type Iterator = interface {
 	// Domain returns the start (inclusive) and end (exclusive) limits of the iterator.
 	// CONTRACT: start, end readonly []byte
-	Domain() (start, end []byte)
+	Domain() (start []byte, end []byte)
 
 	// Valid returns whether the current iterator is valid. Once invalid, the Iterator remains
 	// invalid forever.
@@ -159,5 +157,3 @@ type IteratorI interface {
 	// Close closes the iterator, relasing any allocated resources.
 	Close() error
 }
-
-type Iterator = IteratorI


### PR DESCRIPTION
This reverts commit 38785e92904d435a97e0d1b171089278bddf6760.

This PR retracts v1.1.2 and preps tagging for v1.1.3.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the changelog to reflect the retraction of version v1.1.2 and the release of version v1.1.3.

- **Chores**
  - Marked version v1.1.2 as retracted to prevent its further use.

- **Refactor**
  - Simplified interface names for clearer usage without affecting functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->