### PR TITLE
fix(pebble.go): add intermediate commit to batch if nearing hard limit

### DIFF
--- a/pebble.go
+++ b/pebble.go
@@ -76,6 +76,7 @@ type PebbleDB struct {
 }
 
 var _ DB = (*PebbleDB)(nil)
+const flushThreshold = 3_500_000_000 // ~3.5 GB
 
 func NewPebbleDB(name, dir string, opts Options) (DB, error) {
 	do := &pebble.Options{
@@ -305,6 +306,14 @@ func (b *pebbleDBBatch) Set(key, value []byte) error {
 	}
 	if b.batch == nil {
 		return errBatchClosed
+	// Prevent Pebble batch from exceeding 4 GB hard limit
+	if b.batch.Len() > flushThreshold {
+		if err := b.batch.Commit(pebble.Sync); err != nil {
+			return err
+		}
+		b.batch.Reset()
+	}
+
 	}
 	return b.batch.Set(key, value, nil)
 }
@@ -317,6 +326,14 @@ func (b *pebbleDBBatch) Delete(key []byte) error {
 	if b.batch == nil {
 		return errBatchClosed
 	}
+	// Prevent Pebble batch from exceeding 4 GB hard limit
+	if b.batch.Len() > flushThreshold {
+		if err := b.batch.Commit(pebble.Sync); err != nil {
+			return err
+		}
+		b.batch.Reset()
+	}
+
 	return b.batch.Delete(key, nil)
 }
 

--- a/pebble.go
+++ b/pebble.go
@@ -76,6 +76,7 @@ type PebbleDB struct {
 }
 
 var _ DB = (*PebbleDB)(nil)
+
 const flushThreshold = 3_500_000_000 // ~3.5 GB
 
 func NewPebbleDB(name, dir string, opts Options) (DB, error) {
@@ -306,6 +307,8 @@ func (b *pebbleDBBatch) Set(key, value []byte) error {
 	}
 	if b.batch == nil {
 		return errBatchClosed
+	}
+
 	// Prevent Pebble batch from exceeding 4 GB hard limit
 	if b.batch.Len() > flushThreshold {
 		if err := b.batch.Commit(pebble.Sync); err != nil {
@@ -314,7 +317,6 @@ func (b *pebbleDBBatch) Set(key, value []byte) error {
 		b.batch.Reset()
 	}
 
-	}
 	return b.batch.Set(key, value, nil)
 }
 
@@ -326,6 +328,7 @@ func (b *pebbleDBBatch) Delete(key []byte) error {
 	if b.batch == nil {
 		return errBatchClosed
 	}
+
 	// Prevent Pebble batch from exceeding 4 GB hard limit
 	if b.batch.Len() > flushThreshold {
 		if err := b.batch.Commit(pebble.Sync); err != nil {


### PR DESCRIPTION
Added a flush threshold to prevent Pebble batch from exceeding 4 GB limit during write operations.
Cometbft-db just executes set and delete on the batches without checking for the size. Pebble has a hard-coded limit of batch sizes to 4GB
<img width="784" height="222" alt="grafik" src="https://github.com/user-attachments/assets/d8a8c8f1-cde8-442e-9a2f-7960929c7e38" />

This can lead to node panic in case there is massive data compaction/migrations.