### PR TITLE
perf(goleveldb): use LevelDB Has to skip value reads

### DIFF
--- a/goleveldb.go
+++ b/goleveldb.go
@@ -69,11 +69,10 @@ func (db *GoLevelDB) Get(key []byte) ([]byte, error) {
 
 // Has implements DB.
 func (db *GoLevelDB) Has(key []byte) (bool, error) {
-	bytes, err := db.Get(key)
-	if err != nil {
-		return false, err
+	if len(key) == 0 {
+		return false, errKeyEmpty
 	}
-	return bytes != nil, nil
+	return db.db.Has(key, nil)
 }
 
 // Set implements DB.


### PR DESCRIPTION
Replace `Get()` call with native LevelDB `Has()` method to check key existence without reading the value data. 
This reduces I/O and memory overhead for `Has()` operations.