### PR TITLE
fix(goleveldb): Get returns non-nil for keys with empty values

### DIFF
--- a/goleveldb.go
+++ b/goleveldb.go
@@ -64,6 +64,13 @@ func (db *GoLevelDB) Get(key []byte) ([]byte, error) {
 		}
 		return nil, err
 	}
+	// Normalize nil to empty slice so callers can distinguish
+	// "key not found" (nil) from "key found with empty value" ([]byte{}).
+	// The underlying goleveldb returns nil for both empty values and
+	// successful reads of zero-length data.
+	if res == nil {
+		res = []byte{}
+	}
 	return res, nil
 }
 

--- a/goleveldb_test.go
+++ b/goleveldb_test.go
@@ -28,6 +28,41 @@ func TestGoLevelDBNewGoLevelDB(t *testing.T) {
 	defer ro2.Close()
 }
 
+func TestGoLevelDBEmptyValue(t *testing.T) {
+	name := fmt.Sprintf("test_%x", randStr(12))
+	defer cleanupDBDir("", name)
+
+	db, err := NewGoLevelDB(name, "", nil)
+	require.NoError(t, err)
+	defer db.Close()
+
+	key := []byte("mykey")
+
+	// Set a key with an empty value
+	err = db.Set(key, []byte{})
+	require.NoError(t, err)
+
+	// Has should return true for a key with an empty value
+	has, err := db.Has(key)
+	require.NoError(t, err)
+	require.True(t, has, "Has() should return true for a key with an empty value")
+
+	// Get should return non-nil (empty slice) for a key with an empty value
+	val, err := db.Get(key)
+	require.NoError(t, err)
+	require.NotNil(t, val, "Get() should return non-nil for a key with an empty value")
+	require.Empty(t, val)
+
+	// Verify non-existent key still returns nil
+	val2, err := db.Get([]byte("nonexistent"))
+	require.NoError(t, err)
+	require.Nil(t, val2, "Get() should return nil for a non-existent key")
+
+	has2, err := db.Has([]byte("nonexistent"))
+	require.NoError(t, err)
+	require.False(t, has2)
+}
+
 func BenchmarkGoLevelDBRandomReadsWrites(b *testing.B) {
 	name := fmt.Sprintf("test_%x", randStr(12))
 	db, err := NewGoLevelDB(name, "", nil)


### PR DESCRIPTION
## Summary

- Fix `GoLevelDB.Get()` to return `[]byte{}` instead of `nil` for keys with empty values
- Add test case verifying correct behavior for empty-value keys

## Problem

GoLevelDB's underlying `Get` returns `nil` for both:
1. "key not found" — with `ErrNotFound`
2. "key found with empty value" — without error

After the `ErrNotFound` case is handled, a `nil` result means the key exists with an empty value. However, the current implementation returns this `nil` directly, making it indistinguishable from "key not found".

This causes a critical bug in IAVL v1.2.2: `GetRoot()` checks `val == nil` to determine if a version exists. For IAVL stores with no data (e.g., the `params` module in Cosmos SDK v0.50), `SaveEmptyRoot` writes `[]byte{}` as the root value. `Get` returns `nil` for these keys, causing `GetRoot` to report the version as non-existent. This breaks **all gRPC/REST queries** with:

```
failed to load state at height X; version does not exist (latest height: X)
```

Note: PR #145 fixed `Has()` to use the native LevelDB `Has`, but `Get()` still had this issue.

## Test plan

- [x] Added `TestGoLevelDBEmptyValue` verifying:
  - `Has()` returns `true` for empty-value keys
  - `Get()` returns non-nil `[]byte{}` for empty-value keys  
  - `Get()` returns `nil` for non-existent keys
- [x] Verified fix resolves IAVL query failures in a Cosmos SDK v0.50 chain