### PR TITLE
chore: add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @cosmos/stack-team
+** @cosmos/stack-team

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,1 @@
-# CODEOWNERS: https://help.github.com/articles/about-codeowners/
-
-*       @cosmos/sdk-core-dev
+* @cosmos/stack-team


### PR DESCRIPTION
Adds `.github/CODEOWNERS` to assign `@cosmos/stack-team` as code owners for all files.